### PR TITLE
Suspend fun support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm").version("1.3.41")
+    id("org.jetbrains.kotlin.jvm").version("1.3.50")
     maven
 }
 
@@ -15,9 +15,9 @@ val test by tasks.getting(Test::class) {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0-RC")
-    implementation("com.squareup.retrofit2:retrofit:2.6.0")
-    implementation("com.squareup.okhttp3:okhttp:4.0.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0")
+    implementation("com.squareup.retrofit2:retrofit:2.6.1")
+    implementation("com.squareup.okhttp3:okhttp:4.2.0")
 
     testImplementation("com.squareup.okhttp3:mockwebserver:4.0.1")
     testImplementation("com.google.guava:guava:26.0-jre")

--- a/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapter.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapter.kt
@@ -17,8 +17,14 @@ import java.lang.reflect.Type
  * @constructor Creates a CoroutinesNetworkResponseAdapter
  */
 
-private const val UNKNOWN_ERROR_RESPONSE_CODE = 520
-
+@Deprecated(
+        message = "This class should not be used anymore. Pick DeferredNetworkResponseAdapter or NetworkResponseAdapter based on your needs",
+        replaceWith = ReplaceWith(
+                expression = "DeferredNetworkResponseAdapter",
+                imports = ["com.haroldadmin.cnradapter.DeferredNetworkResponseAdapter"]
+        ),
+        level = DeprecationLevel.WARNING
+)
 internal class CoroutinesNetworkResponseAdapter<T : Any, U : Any>(
     private val successBodyType: Type,
     private val errorConverter: Converter<ResponseBody, U>
@@ -48,6 +54,7 @@ internal class CoroutinesNetworkResponseAdapter<T : Any, U : Any>(
 
         call.enqueue(object : Callback<T> {
             override fun onFailure(call: Call<T>, throwable: Throwable) {
+                // TODO Use ErrorExtraction methods here
                 when (throwable) {
 
                     is IOException -> deferred.complete(NetworkResponse.NetworkError(throwable))

--- a/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapterFactory.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapterFactory.kt
@@ -10,12 +10,23 @@ import java.lang.reflect.Type
 /**
  * A Factory class to create instances of [CoroutinesNetworkResponseAdapter]
  */
+@Deprecated(
+        message = "This class should not be used anymore. Replace with NetworkResponseAdapterFactory",
+        replaceWith = ReplaceWith(
+                expression = "NetworkResponseAdapterFactory",
+                imports = ["com.haroldadmin.cnradapter.NetworkResponseAdapterFactory"]
+        ),
+        level = DeprecationLevel.WARNING
+)
 class CoroutinesNetworkResponseAdapterFactory private constructor() : CallAdapter.Factory() {
 
     companion object {
         @JvmStatic
         @JvmName("create")
-        operator fun invoke() = CoroutinesNetworkResponseAdapterFactory()
+        @Suppress("DEPRECATION")
+        operator fun invoke(): CoroutinesNetworkResponseAdapterFactory {
+            throw UnsupportedOperationException("Use NetworkResponseAdapterFactory instead of this class")
+        }
     }
 
     /**
@@ -26,22 +37,15 @@ class CoroutinesNetworkResponseAdapterFactory private constructor() : CallAdapte
         if (Deferred::class.java != rawType) {
             return null
         }
-        if (returnType !is ParameterizedType) {
-            throw IllegalStateException(
-                    "Deferred return must be parameterized as Deferred<Foo> or Deferred<out Foo>"
-            )
-        }
+
+        check(returnType is ParameterizedType) { "Deferred return must be parameterized as Deferred<Foo> or Deferred<out Foo>" }
 
         val containerType = getParameterUpperBound(0, returnType)
         if (getRawType(containerType) != NetworkResponse::class.java) {
             return null
         }
 
-        if (containerType !is ParameterizedType) {
-            throw IllegalStateException(
-                    "NetworkResponse must be parameterized as NetworkResponse<SuccessBody, ErrorBody>"
-            )
-        }
+        check(containerType is ParameterizedType) { "NetworkResponse must be parameterized as NetworkResponse<SuccessBody, ErrorBody>" }
 
         val successBodyType = getParameterUpperBound(0, containerType)
         val errorBodyType = getParameterUpperBound(1, containerType)
@@ -50,6 +54,7 @@ class CoroutinesNetworkResponseAdapterFactory private constructor() : CallAdapte
                 errorBodyType,
                 annotations
         )
+        @Suppress("DEPRECATION")
         return CoroutinesNetworkResponseAdapter<Any, Any>(successBodyType, errorBodyConverter)
     }
 }

--- a/src/main/kotlin/com/haroldadmin/cnradapter/DeferredNetworkResponseAdapter.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/DeferredNetworkResponseAdapter.kt
@@ -1,0 +1,68 @@
+package com.haroldadmin.cnradapter
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import okhttp3.ResponseBody
+import retrofit2.*
+import java.io.IOException
+import java.lang.reflect.Type
+
+/**
+ * A Retrofit converter to return objects wrapped in [NetworkResponse] class
+ *
+ * @param T The type of the successful response model
+ * @param U The type of the error response model
+ * @param successBodyType The type of the successful response model in [NetworkResponse]
+ * @param errorConverter The converter to extract error information from [ResponseBody]
+ * @constructor Creates a DeferredNetworkResponseAdapter
+ */
+
+internal class DeferredNetworkResponseAdapter<T : Any, U : Any>(
+        private val successBodyType: Type,
+        private val errorConverter: Converter<ResponseBody, U>
+) : CallAdapter<T, Deferred<NetworkResponse<T, U>>> {
+
+    /**
+     * This is used to determine the parameterize type of the object
+     * being handled by this adapter. For example, the response type
+     * in Call<Repo> is Repo.
+     */
+    override fun responseType(): Type = successBodyType
+
+    /**
+     * Returns an instance of [T] by modifying a [Call] object
+     *
+     * @param call The call object to be converted
+     * @return The T instance wrapped in a [NetworkResponse] class wrapped in [Deferred]
+     */
+    override fun adapt(call: Call<T>): Deferred<NetworkResponse<T, U>> {
+        val deferred = CompletableDeferred<NetworkResponse<T, U>>()
+
+        deferred.invokeOnCompletion {
+            if (deferred.isCancelled) {
+                call.cancel()
+            }
+        }
+
+        call.enqueue(object : Callback<T> {
+            override fun onFailure(call: Call<T>, throwable: Throwable) {
+                try {
+                    val networkResponse = throwable.extractNetworkResponse<T, U>(errorConverter)
+                    deferred.complete(networkResponse)
+                } catch (t: Throwable) {
+                    deferred.completeExceptionally(t)
+                }
+            }
+
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                val headers = response.headers()
+                val responseCode = response.code()
+                val body = response.body()
+                body?.let {
+                    deferred.complete(NetworkResponse.Success(it, headers))
+                } ?: deferred.complete(NetworkResponse.ServerError(null, responseCode, headers))
+            }
+        })
+
+        return deferred
+    }
+}

--- a/src/main/kotlin/com/haroldadmin/cnradapter/ErrorExtraction.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/ErrorExtraction.kt
@@ -1,0 +1,34 @@
+package com.haroldadmin.cnradapter
+
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.HttpException
+import java.io.IOException
+
+internal const val UNKNOWN_ERROR_RESPONSE_CODE = 520
+
+internal fun <S : Any, E : Any> HttpException.extractFromHttpException(errorConverter: Converter<ResponseBody, E>): NetworkResponse<S, E> {
+    val error = response()?.errorBody()
+    val responseCode = response()?.code() ?: UNKNOWN_ERROR_RESPONSE_CODE
+    val headers = response()?.headers()
+    val errorBody = when {
+        error == null -> null // No error content available
+        error.contentLength() == 0L -> null // Error content is empty
+        else -> try {
+            // There is error content present, so we should try to extract it
+            errorConverter.convert(error)
+        } catch (e: Exception) {
+            // If unable to extract content, return with a null body and don't parse further
+            return NetworkResponse.ServerError(null, responseCode, headers)
+        }
+    }
+    return NetworkResponse.ServerError(errorBody, responseCode, headers)
+}
+
+internal fun <S : Any, E : Any> Throwable.extractNetworkResponse(errorConverter: Converter<ResponseBody, E>): NetworkResponse<S, E> {
+    return when (this) {
+        is IOException -> NetworkResponse.NetworkError(this)
+        is HttpException -> extractFromHttpException<S, E>(errorConverter)
+        else -> throw this
+    }
+}

--- a/src/main/kotlin/com/haroldadmin/cnradapter/Extensions.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/Extensions.kt
@@ -15,11 +15,11 @@ import kotlinx.coroutines.delay
  * @return The NetworkResponse value whether it be successful or failed after retrying
  */
 suspend inline fun <T : Any, U : Any> executeWithRetry(
-    times: Int = 10,
-    initialDelay: Long = 100, // 0.1 second
-    maxDelay: Long = 1000, // 1 second
-    factor: Double = 2.0,
-    block: () -> NetworkResponse<T, U>
+        times: Int = 10,
+        initialDelay: Long = 100, // 0.1 second
+        maxDelay: Long = 1000, // 1 second
+        factor: Double = 2.0,
+        block: suspend () -> NetworkResponse<T, U>
 ): NetworkResponse<T, U> {
     var currentDelay = initialDelay
     repeat(times - 1) {

--- a/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseAdapter.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseAdapter.kt
@@ -1,0 +1,20 @@
+package com.haroldadmin.cnradapter
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Converter
+import java.lang.reflect.Type
+
+class NetworkResponseAdapter<S : Any, E : Any>(
+        private val successType: Type,
+        private val errorBodyConverter: Converter<ResponseBody, E>
+) : CallAdapter<S, Call<NetworkResponse<S, E>>> {
+
+    override fun responseType(): Type = successType
+
+    override fun adapt(call: Call<S>): Call<NetworkResponse<S, E>> {
+        return NetworkResponseCall(call, errorBodyConverter)
+    }
+}
+

--- a/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseAdapterFactory.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseAdapterFactory.kt
@@ -1,0 +1,43 @@
+package com.haroldadmin.cnradapter
+
+import kotlinx.coroutines.Deferred
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class NetworkResponseAdapterFactory : CallAdapter.Factory() {
+
+    override fun get(returnType: Type, annotations: Array<Annotation>, retrofit: Retrofit): CallAdapter<*, *>? {
+
+        check(returnType is ParameterizedType) { "$returnType must be parameterized. Raw types are not supported" }
+
+        val containerType = getParameterUpperBound(0, returnType)
+        if (getRawType(containerType) != NetworkResponse::class.java) {
+            return null
+        }
+
+        check(containerType is ParameterizedType) { "$containerType must be parameterized. Raw types are not supported" }
+
+        val (successBodyType, errorBodyType) = containerType.getBodyTypes()
+        val errorBodyConverter = retrofit.nextResponseBodyConverter<Any>(null, errorBodyType, annotations)
+
+        return when (getRawType(returnType)) {
+            Deferred::class.java -> {
+                DeferredNetworkResponseAdapter<Any, Any>(successBodyType, errorBodyConverter)
+            }
+
+            Call::class.java -> {
+                NetworkResponseAdapter<Any, Any>(successBodyType, errorBodyConverter)
+            }
+            else -> null
+        }
+    }
+
+    private fun ParameterizedType.getBodyTypes(): Pair<Type, Type> {
+        val successType = getParameterUpperBound(0, this)
+        val errorType = getParameterUpperBound(1, this)
+        return successType to errorType
+    }
+}

--- a/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseCall.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponseCall.kt
@@ -1,0 +1,52 @@
+package com.haroldadmin.cnradapter
+
+import okhttp3.Request
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Converter
+import retrofit2.Response
+
+internal class NetworkResponseCall<S : Any, E : Any>(
+        private val backingCall: Call<S>,
+        private val errorConverter: Converter<ResponseBody, E>
+) : Call<NetworkResponse<S, E>> {
+
+    override fun enqueue(callback: Callback<NetworkResponse<S, E>>) = synchronized(this) {
+        backingCall.enqueue(object : Callback<S> {
+            override fun onResponse(call: Call<S>, response: Response<S>) {
+                val body = response.body()
+                if (body != null) {
+                    callback.onResponse(this@NetworkResponseCall, Response.success(NetworkResponse.Success(body, response.headers())))
+                } else {
+                    callback.onResponse(this@NetworkResponseCall, Response.success(NetworkResponse.ServerError(null, response.code(), response.headers())))
+                }
+            }
+
+            override fun onFailure(call: Call<S>, throwable: Throwable) {
+                val networkResponse = throwable.extractNetworkResponse<S, E>(errorConverter)
+                callback.onResponse(this@NetworkResponseCall, Response.success(networkResponse))
+            }
+        })
+    }
+
+    override fun isExecuted(): Boolean = synchronized(this) {
+        backingCall.isExecuted
+    }
+
+    override fun clone(): Call<NetworkResponse<S, E>> = NetworkResponseCall(backingCall.clone(), errorConverter)
+
+    override fun isCanceled(): Boolean = synchronized(this) {
+        backingCall.isCanceled
+    }
+
+    override fun cancel() = synchronized(this) {
+        backingCall.cancel()
+    }
+
+    override fun execute(): Response<NetworkResponse<S, E>> {
+        throw UnsupportedOperationException("Network Response call does not support synchronous execution")
+    }
+
+    override fun request(): Request = backingCall.request()
+}

--- a/src/test/kotlin/com/haroldadmin/cnradapter/CancelTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/CancelTest.kt
@@ -11,7 +11,7 @@ import java.io.IOException
 internal class CancelTest : DescribeSpec({
 
     val mockWebServer = MockWebServer()
-    val factory = CoroutinesNetworkResponseAdapterFactory()
+    val factory = NetworkResponseAdapterFactory()
     val retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
             .addConverterFactory(StringConverterFactory())

--- a/src/test/kotlin/com/haroldadmin/cnradapter/DeferredTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/DeferredTest.kt
@@ -25,7 +25,7 @@ internal class DeferredTest : DescribeSpec() {
         retrofit = Retrofit.Builder()
                 .baseUrl(server.url("/"))
                 .addConverterFactory(StringConverterFactory())
-                .addCallAdapterFactory(CoroutinesNetworkResponseAdapterFactory())
+                .addCallAdapterFactory(NetworkResponseAdapterFactory())
                 .callbackExecutor(executor)
                 .build()
         service = retrofit.create(Service::class.java)
@@ -94,7 +94,7 @@ internal class DeferredTest : DescribeSpec() {
             }
 
             context("IO error") {
-                server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST))
+                server.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
 
                 it("Should be treated as NetworkResponse.NetworkError") {
                     val response = service.getText().await()

--- a/src/test/kotlin/com/haroldadmin/cnradapter/ErrorExtractionTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/ErrorExtractionTest.kt
@@ -1,0 +1,56 @@
+package com.haroldadmin.cnradapter
+
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.shouldBe
+import okhttp3.Headers
+import okhttp3.ResponseBody
+import retrofit2.HttpException
+import retrofit2.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import retrofit2.Converter
+import retrofit2.http.Header
+import java.io.IOException
+import java.lang.Exception
+
+internal class ErrorExtractionTest {
+
+    private val errorConverter = Converter<ResponseBody, String> { responseBody -> responseBody.toString() }
+
+    @Test
+    fun `extract error from HttpException test`() {
+        val serverResponse = "Server Error".toResponseBody()
+        val response = Response.error<String>(404, serverResponse)
+        val exception = HttpException(response)
+        with(exception.extractFromHttpException<String, String>(errorConverter)) {
+
+            shouldBeTypeOf<NetworkResponse.ServerError<String>>()
+            this as NetworkResponse.ServerError
+
+            body shouldBe errorConverter.convert(serverResponse)
+            code shouldBe 404
+            headers shouldBe Headers.headersOf()
+        }
+    }
+
+    @Test
+    fun `extract error from IOException test`() {
+        val ioException = IOException()
+        with(ioException.extractNetworkResponse<String, String>(errorConverter)) {
+
+            shouldBeTypeOf<NetworkResponse.NetworkError>()
+            this as NetworkResponse.NetworkError
+
+            error shouldBeSameInstanceAs ioException
+        }
+    }
+
+    private class CustomException: Exception()
+
+    @Test(expected = CustomException::class)
+    fun `extract error from an unknown exception test`() {
+        val exception = CustomException()
+        exception.extractNetworkResponse<String, String>(errorConverter)
+    }
+}

--- a/src/test/kotlin/com/haroldadmin/cnradapter/FactoryTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/FactoryTest.kt
@@ -5,6 +5,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.DescribeSpec
 import kotlinx.coroutines.Deferred
 import okhttp3.mockwebserver.MockWebServer
+import retrofit2.Call
 import retrofit2.Retrofit
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -12,14 +13,14 @@ import java.util.concurrent.Executors
 internal class FactoryTest : DescribeSpec() {
 
     private lateinit var mockWebServer: MockWebServer
-    private lateinit var callAdapterFactory: CoroutinesNetworkResponseAdapterFactory
+    private lateinit var callAdapterFactory: NetworkResponseAdapterFactory
     private lateinit var retrofit: Retrofit
     private lateinit var executor: ExecutorService
 
     override fun beforeSpec(spec: Spec) {
         super.beforeSpec(spec)
         mockWebServer = MockWebServer()
-        callAdapterFactory = CoroutinesNetworkResponseAdapterFactory()
+        callAdapterFactory = NetworkResponseAdapterFactory()
         executor = Executors.newSingleThreadExecutor()
         retrofit = Retrofit.Builder()
                 .baseUrl(mockWebServer.url("/"))
@@ -45,9 +46,15 @@ internal class FactoryTest : DescribeSpec() {
                     callAdapterFactory.get(bodyClass, emptyArray(), retrofit) shouldBe null
                 }
             }
-            context("Request type if Deferred<NetworkResponse>") {
+            context("Request type is Deferred<NetworkResponse>") {
                 val bodyClass = typeOf<Deferred<NetworkResponse<String, String>>>()
                 it("Should return correct type") {
+                    callAdapterFactory.get(bodyClass, emptyArray(), retrofit)!!.responseType() shouldBe String::class.java
+                }
+            }
+            context("Request type is NetworkResponse") {
+                val bodyClass = typeOf<Call<NetworkResponse<String, String>>>()
+                it("should return the correct type") {
                     callAdapterFactory.get(bodyClass, emptyArray(), retrofit)!!.responseType() shouldBe String::class.java
                 }
             }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/NetworkResponseCallTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/NetworkResponseCallTest.kt
@@ -1,0 +1,107 @@
+package com.haroldadmin.cnradapter
+
+import com.haroldadmin.cnradapter.CompletableCall
+import com.haroldadmin.cnradapter.NetworkResponse
+import com.haroldadmin.cnradapter.NetworkResponseCall
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.matchers.types.shouldNotBeSameInstanceAs
+import io.kotlintest.shouldBe
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import retrofit2.*
+import java.io.IOException
+
+internal class NetworkResponseCallTest {
+    private val errorConverter = Converter<ResponseBody, String> { it.toString() }
+    private val backingCall = CompletableCall<String>()
+    private val networkResponseCall = NetworkResponseCall<String, String>(backingCall, errorConverter)
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun `should throw an error when invoking 'execute'`() {
+        networkResponseCall.execute()
+    }
+
+    @Test
+    fun `should delegate properties to backing call`() {
+        with (networkResponseCall) {
+            isExecuted shouldBe backingCall.isExecuted
+            isCanceled shouldBe backingCall.isCanceled
+            request() shouldBe backingCall.request()
+        }
+    }
+
+    @Test
+    fun `should return new instance when cloned`() {
+        val clonedCall = networkResponseCall.clone()
+        clonedCall shouldNotBeSameInstanceAs networkResponseCall
+    }
+
+    @Test
+    fun `should cancel backing call as well when canceled`() {
+        networkResponseCall.cancel()
+        assert(backingCall.isCanceled)
+    }
+
+    @Test
+    fun `should parse successful call as NetworkResponse Success`() {
+        val body = "Test body"
+        networkResponseCall.enqueue(object : Callback<NetworkResponse<String, String>> {
+            override fun onResponse(call: Call<NetworkResponse<String, String>>, response: Response<NetworkResponse<String, String>>) {
+                assert(response.isSuccessful)
+                response.body().shouldBeTypeOf<NetworkResponse.Success<String>>()
+                (response.body()!! as NetworkResponse.Success).body shouldBe body
+            }
+
+            override fun onFailure(call: Call<NetworkResponse<String, String>>, t: Throwable) {
+                throw IllegalStateException()
+            }
+        })
+        backingCall.complete(body)
+    }
+
+    @Test
+    fun `should parse unsuccessful call with HttpException as NetworkResponse ServerError`() {
+        networkResponseCall.enqueue(object : Callback<NetworkResponse<String, String>> {
+            override fun onResponse(call: Call<NetworkResponse<String, String>>, response: Response<NetworkResponse<String, String>>) {
+                response.body().shouldBeTypeOf<NetworkResponse.ServerError<String>>()
+            }
+
+            override fun onFailure(call: Call<NetworkResponse<String, String>>, t: Throwable) {
+                throw IllegalStateException()
+            }
+        })
+
+        backingCall.completeWithException(HttpException(Response.error<String>(404, "Server Error".toResponseBody())))
+    }
+
+    @Test
+    fun `should parse unsuccessful call with IOException as NetworkResponse NetworkError`() {
+        networkResponseCall.enqueue(object: Callback<NetworkResponse<String, String>> {
+            override fun onFailure(call: Call<NetworkResponse<String, String>>, t: Throwable) {
+                throw IllegalStateException()
+            }
+
+            override fun onResponse(call: Call<NetworkResponse<String, String>>, response: Response<NetworkResponse<String, String>>) {
+                response.body().shouldBeTypeOf<NetworkResponse.NetworkError>()
+            }
+        })
+
+        backingCall.completeWithException(IOException())
+    }
+
+    @Test
+    fun `should parse successful call with empty body as NetworkResponse ServerError`() {
+        networkResponseCall.enqueue(object : Callback<NetworkResponse<String, String>> {
+            override fun onFailure(call: Call<NetworkResponse<String, String>>, t: Throwable) {
+                throw IllegalStateException()
+            }
+
+            override fun onResponse(call: Call<NetworkResponse<String, String>>, response: Response<NetworkResponse<String, String>>) {
+                response.body().shouldBeTypeOf<NetworkResponse.ServerError<String>>()
+            }
+        })
+
+        backingCall.complete(Response.error(404, "".toResponseBody()))
+    }
+}

--- a/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
@@ -4,6 +4,7 @@ import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.DescribeSpec
+import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -23,11 +24,11 @@ class ExtensionsTest : DescribeSpec() {
         server = MockWebServer()
         executor = Executors.newSingleThreadExecutor()
         retrofit = Retrofit.Builder()
-            .baseUrl(server.url("/"))
-            .callbackExecutor(executor)
-            .addCallAdapterFactory(NetworkResponseAdapterFactory())
-            .addConverterFactory(StringConverterFactory())
-            .build()
+                .baseUrl(server.url("/"))
+                .callbackExecutor(executor)
+                .addCallAdapterFactory(NetworkResponseAdapterFactory())
+                .addConverterFactory(StringConverterFactory())
+                .build()
         service = retrofit.create(Service::class.java)
     }
 
@@ -40,22 +41,45 @@ class ExtensionsTest : DescribeSpec() {
     init {
         describe("Execute with retry") {
 
-            repeat(9) {
-                val mockResponse = MockResponse()
-                server.enqueue(mockResponse.apply { mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
+            context("Deferred response") {
+                repeat(9) {
+                    val mockResponse = MockResponse()
+                    server.enqueue(mockResponse.apply { mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
+                }
+
+                server.enqueue(MockResponse().setBody("Hi!"))
+
+                val response = executeWithRetry(times = 10) {
+                    service.getText().await()
+                }
+
+                it("Should end up with NetworkResponse.Success after 10 retries") {
+                    (response is NetworkResponse.Success) shouldBe true
+                    with(response as NetworkResponse.Success) {
+                        body shouldBe "Hi!"
+                        headers shouldNotBe null
+                    }
+                }
             }
 
-            server.enqueue(MockResponse().setBody("Hi!"))
+            context("Suspending response") {
+                repeat(9) {
+                    val mockResponse = MockResponse()
+                    server.enqueue(mockResponse.apply { mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
+                }
 
-            val response = executeWithRetry(times = 10) {
-                service.getText().await()
-            }
+                server.enqueue(MockResponse().setBody("Hi!"))
 
-            it("Should end up with NetworkResponse.Success after 10 retries") {
-                (response is NetworkResponse.Success) shouldBe true
-                with(response as NetworkResponse.Success) {
-                    body shouldBe "Hi!"
-                    headers shouldNotBe null
+                val response = executeWithRetry(times = 10) {
+                    runBlocking { service.getTextSuspend() }
+                }
+
+                it("Should end up with NetworkResponse.Success after 10 retries") {
+                    (response is NetworkResponse.Success) shouldBe true
+                    with(response as NetworkResponse.Success) {
+                        body shouldBe "Hi!"
+                        headers shouldNotBe null
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
@@ -71,7 +71,7 @@ class ExtensionsTest : DescribeSpec() {
                 server.enqueue(MockResponse().setBody("Hi!"))
 
                 val response = executeWithRetry(times = 10) {
-                    runBlocking { service.getTextSuspend() }
+                    service.getTextSuspend()
                 }
 
                 it("Should end up with NetworkResponse.Success after 10 retries") {

--- a/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/RetryTest.kt
@@ -25,7 +25,7 @@ class ExtensionsTest : DescribeSpec() {
         retrofit = Retrofit.Builder()
             .baseUrl(server.url("/"))
             .callbackExecutor(executor)
-            .addCallAdapterFactory(CoroutinesNetworkResponseAdapterFactory())
+            .addCallAdapterFactory(NetworkResponseAdapterFactory())
             .addConverterFactory(StringConverterFactory())
             .build()
         service = retrofit.create(Service::class.java)
@@ -41,7 +41,8 @@ class ExtensionsTest : DescribeSpec() {
         describe("Execute with retry") {
 
             repeat(9) {
-                server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST))
+                val mockResponse = MockResponse()
+                server.enqueue(mockResponse.apply { mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
             }
 
             server.enqueue(MockResponse().setBody("Hi!"))

--- a/src/test/kotlin/com/haroldadmin/cnradapter/Service.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/Service.kt
@@ -6,4 +6,7 @@ import retrofit2.http.GET
 interface Service {
     @GET("/")
     fun getText(): Deferred<NetworkResponse<String, String>>
+
+    @GET("/suspend")
+    suspend fun getTextSuspend(): NetworkResponse<String, String>
 }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
@@ -1,0 +1,2 @@
+package com.haroldadmin.cnradapter
+

--- a/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
@@ -1,2 +1,91 @@
 package com.haroldadmin.cnradapter
 
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class SuspendTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var executor: ExecutorService
+    private lateinit var retrofit: Retrofit
+    private lateinit var service: Service
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        executor = Executors.newSingleThreadExecutor()
+        retrofit = Retrofit.Builder()
+                .baseUrl(server.url("/suspend/"))
+                .addConverterFactory(StringConverterFactory())
+                .addCallAdapterFactory(NetworkResponseAdapterFactory())
+                .callbackExecutor(executor)
+                .build()
+        service = retrofit.create(Service::class.java)
+    }
+
+    @Test
+    fun `successful response test`() {
+        val responseBody = "Hi!"
+        server.enqueue(
+                MockResponse()
+                        .setBody(responseBody)
+                        .setResponseCode(200)
+                        .setHeader("TEST","test")
+        )
+
+        val response = runBlocking {
+            service.getTextSuspend()
+        }
+
+        with(response) {
+            shouldBeTypeOf<NetworkResponse.Success<String>>()
+            this as NetworkResponse.Success
+            body shouldBe responseBody
+            headers shouldNotBe null
+            headers!!["TEST"] shouldBe "test"
+        }
+    }
+
+    @Test
+    fun `empty response test`() {
+        val responseCode = 404
+        server.enqueue(
+                MockResponse()
+                        .setResponseCode(responseCode)
+                        .setHeader("TEST", "test")
+        )
+        val response = runBlocking { service.getTextSuspend() }
+
+        with (response) {
+            shouldBeTypeOf<NetworkResponse.ServerError<String>>()
+            this as NetworkResponse.ServerError
+            code shouldBe responseCode
+            body shouldBe null
+            headers!!["TEST"] shouldBe "test"
+        }
+    }
+
+    @Test
+    fun `network error test`() {
+        server.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST })
+        val response = runBlocking { service.getTextSuspend() }
+        response.shouldBeTypeOf<NetworkResponse.NetworkError>()
+    }
+
+    @After
+    fun cleanup() {
+        server.close()
+        executor.shutdown()
+    }
+}


### PR DESCRIPTION
Fixes Issue #2 

Changes:
* Adds support for suspending functions with `NetworkResponse` as the return type.
* Deprecate CoroutinesNetworkResponseAdapter and CoroutinesNetworkResponseAdapterFactory
* Add support for suspending functions in `executeWithRetry`

Since there are deprecations in this PR, when this is merged I plan to release a 3.0 version of this adapter instead of a 2.2 version.