### PR TITLE
Add response code to NetworkResponse.Success

### DIFF
--- a/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapter.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/CoroutinesNetworkResponseAdapter.kt
@@ -94,7 +94,7 @@ internal class CoroutinesNetworkResponseAdapter<T : Any, U : Any>(
                 val responseCode = response.code()
                 val body = response.body()
                 body?.let {
-                    deferred.complete(NetworkResponse.Success(it, headers))
+                    deferred.complete(NetworkResponse.Success(it, headers, responseCode))
                 } ?: deferred.complete(NetworkResponse.ServerError(null, responseCode, headers))
             }
         })

--- a/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponse.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/NetworkResponse.kt
@@ -7,7 +7,11 @@ sealed class NetworkResponse<out T : Any, out U : Any> {
     /**
      * A request that resulted in a response with a 2xx status code that has a body.
      */
-    data class Success<T : Any>(val body: T, val headers: Headers? = null) : NetworkResponse<T, Nothing>()
+    data class Success<T : Any>(
+        val body: T,
+        val headers: Headers? = null,
+        val code: Int
+    ) : NetworkResponse<T, Nothing>()
 
     /**
      * A request that resulted in a response with a non-2xx status code.

--- a/src/main/kotlin/com/haroldadmin/cnradapter/ResponseHandler.kt
+++ b/src/main/kotlin/com/haroldadmin/cnradapter/ResponseHandler.kt
@@ -36,13 +36,13 @@ internal object ResponseHandler {
 
         return if (response.isSuccessful) {
             if (body != null) {
-                NetworkResponse.Success(body, headers)
+                NetworkResponse.Success(body, headers, code)
             } else {
                 // Special case: If the response is successful and the body is null, return a successful response
                 // if the service method declares the success body type as Unit. Otherwise, return a server error
                 if (successBodyType == Unit::class.java) {
                     @Suppress("UNCHECKED_CAST")
-                    NetworkResponse.Success(Unit, headers) as NetworkResponse<S, E>
+                    NetworkResponse.Success(Unit, headers, code) as NetworkResponse<S, E>
                 } else {
                     NetworkResponse.ServerError(null, code, headers)
                 }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/DeferredTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/DeferredTest.kt
@@ -60,6 +60,7 @@ internal class DeferredTest : DescribeSpec() {
                         body shouldBe responseBody
                         headers shouldNotBe null
                         headers!!.get("TEST") shouldBe "test"
+                        code shouldBe 200
                     }
                 }
             }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/InvokeOperatorTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/InvokeOperatorTest.kt
@@ -8,7 +8,7 @@ import java.io.IOException
 
 private class MessageRepo {
     fun getMessage(): Deferred<NetworkResponse<String, String>> {
-        return CompletableDeferred(NetworkResponse.Success("Hello!"))
+        return CompletableDeferred(NetworkResponse.Success("Hello!", null, 200))
     }
 
     fun getMessageError(): Deferred<NetworkResponse<String, String>> {

--- a/src/test/kotlin/com/haroldadmin/cnradapter/MoshiApplicationTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/MoshiApplicationTest.kt
@@ -119,6 +119,7 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.Success<Launch>>()
         response as NetworkResponse.Success
         response.body.name shouldContain "FalconSat"
+        response.code shouldBe 200
     }
 
     @Test
@@ -133,6 +134,7 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.ServerError<GenericErrorResponse>>()
         response as NetworkResponse.ServerError
         response.body!!.error shouldContain "Not Found"
+        response.code shouldBe 404
     }
 
     @Test
@@ -174,6 +176,7 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.Success<Launch>>()
         response as NetworkResponse.Success
         response.body.name shouldContain "FalconSat"
+        response.code shouldBe 200
     }
 
     @Test
@@ -188,6 +191,7 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.ServerError<GenericErrorResponse>>()
         response as NetworkResponse.ServerError
         response.body!!.error shouldContain "Not Found"
+        response.code shouldBe 404
     }
 
     @Test
@@ -229,6 +233,7 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.Success<Unit>>()
         response as NetworkResponse.Success
         response.body shouldBe Unit
+        response.code shouldBe 204
     }
 
     @Test
@@ -242,5 +247,6 @@ internal class MoshiApplicationTest: AnnotationSpec() {
         response.shouldBeInstanceOf<NetworkResponse.Success<Unit>>()
         response as NetworkResponse.Success
         response.body shouldBe Unit
+        response.code shouldBe 204
     }
 }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/SuspendTest.kt
@@ -52,6 +52,7 @@ internal class SuspendTest: AnnotationSpec() {
             body shouldBe responseBody
             headers shouldNotBe null
             headers!!["TEST"] shouldBe "test"
+            code shouldBe 200
         }
     }
 
@@ -94,6 +95,7 @@ internal class SuspendTest: AnnotationSpec() {
             shouldBeTypeOf<NetworkResponse.Success<Unit>>()
             this as NetworkResponse.Success
             body shouldBe Unit
+            code shouldBe 204
         }
     }
 
@@ -110,6 +112,7 @@ internal class SuspendTest: AnnotationSpec() {
             shouldBeTypeOf<NetworkResponse.ServerError<String>>()
             this as NetworkResponse.ServerError
             body shouldBe ""
+            code shouldBe 400
         }
     }
 


### PR DESCRIPTION
Adds a response code field to `NetworkResponse.Success` class, and updates tests to validated it.

Fixes #15 