### PR TITLE
Added [NetworkResponse.Error] an interface to generalize errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ It is generic on two types: a response (`S`), and an error (`E`). The response t
           is NetworkResponse.Success -> {
               // Handle successful response
           }
+          is NetworkResponse.Error -> {
+              // Handle error
+          }
+      }
+  
+      // If you care about what type of error
+      when (person) {
+          is NetworkResponse.Success -> {
+              // Handle successful response
+          }
           is NetworkResponse.ServerError -> {
               // Handle server error
           }

--- a/src/test/kotlin/com/haroldadmin/cnradapter/ErrorExtractionTest.kt
+++ b/src/test/kotlin/com/haroldadmin/cnradapter/ErrorExtractionTest.kt
@@ -22,10 +22,10 @@ internal class ErrorExtractionTest: AnnotationSpec() {
         val serverResponse = "Server Error".toResponseBody()
         val response = Response.error<String>(404, serverResponse)
         val exception = HttpException(response)
-        with(exception.extractFromHttpException<String>(errorConverter)) {
+        with(exception.extractFromHttpException(errorConverter)) {
 
             shouldBeTypeOf<NetworkResponse.ServerError<String>>()
-            this as NetworkResponse.ServerError
+
 
             body shouldBe errorConverter.convert(serverResponse)
             code shouldBe 404
@@ -54,7 +54,7 @@ internal class ErrorExtractionTest: AnnotationSpec() {
         with(response) {
             shouldBeTypeOf<NetworkResponse.UnknownError>()
             this as NetworkResponse.UnknownError
-            this.error shouldBe exception
+            error shouldBe exception
         }
     }
 }


### PR DESCRIPTION
There are cases where I don't care what was the type of the error, I just want to know that there was an error without specifying the type each time